### PR TITLE
fix: Remove timeout on preimage fetch retries

### DIFF
--- a/bin/host/src/backend/online.rs
+++ b/bin/host/src/backend/online.rs
@@ -8,8 +8,8 @@ use kona_preimage::{
     errors::{PreimageOracleError, PreimageOracleResult},
 };
 use kona_proof::{Hint, errors::HintParsingError};
-use std::{collections::HashSet, hash::Hash, str::FromStr, sync::Arc, time::Duration};
-use tokio::{sync::RwLock, time::timeout};
+use std::{collections::HashSet, hash::Hash, str::FromStr, sync::Arc};
+use tokio::sync::RwLock;
 use tracing::{debug, error, trace};
 
 /// The [OnlineHostBackendCfg] trait is used to define the type configuration for the
@@ -132,25 +132,20 @@ where
         drop(kv_lock);
 
         // Use a loop to keep retrying the prefetch as long as the key is not found
-        timeout(Duration::from_secs(10), async {
-            while preimage.is_none() {
-                if let Some(hint) = self.last_hint.read().await.as_ref() {
-                    let value =
-                        H::fetch_hint(hint.clone(), &self.cfg, &self.providers, self.kv.clone())
-                            .await;
+        while preimage.is_none() {
+            if let Some(hint) = self.last_hint.read().await.as_ref() {
+                let value =
+                    H::fetch_hint(hint.clone(), &self.cfg, &self.providers, self.kv.clone()).await;
 
-                    if let Err(e) = value {
-                        error!(target: "host_backend", "Failed to prefetch hint: {e}");
-                        continue;
-                    }
-
-                    let kv_lock = self.kv.read().await;
-                    preimage = kv_lock.get(key.into());
+                if let Err(e) = value {
+                    error!(target: "host_backend", "Failed to prefetch hint: {e}");
+                    continue;
                 }
+
+                let kv_lock = self.kv.read().await;
+                preimage = kv_lock.get(key.into());
             }
-        })
-        .await
-        .map_err(|_| PreimageOracleError::Timeout)?;
+        }
 
         preimage.ok_or(PreimageOracleError::KeyNotFound)
     }


### PR DESCRIPTION
see: https://github.com/op-rs/kona/pull/3196

The timeout meant brief RPC outages caused kona execution to hang forever because kona-host exited without providing the required preimage. kona-host should continue retrying for as long as it takes to retrieve the preimage.