### PR TITLE
kona-proof: fix TipCursor using zero output root instead of agreed pr…

### DIFF
--- a/bin/client/src/interop/transition.rs
+++ b/bin/client/src/interop/transition.rs
@@ -76,6 +76,11 @@ where
         .header_by_hash(safe_head_hash)
         .map(|header| Sealed::new_unchecked(header, safe_head_hash))?;
     let disputed_l2_block_number = safe_head.number + 1;
+    let agreed_l2_output_root = boot
+        .agreed_pre_state
+        .active_l2_output_root()
+        .map(|root| root.output_root)
+        .ok_or(FaultProofProgramError::StateTransitionFailed)?;
 
     // Check if we can no-op the transition. The Superchain STF happens once every second, but
     // chains have a variable block time, meaning there might be no transition to process.
@@ -101,6 +106,7 @@ where
     let cursor = new_oracle_pipeline_cursor(
         rollup_config.as_ref(),
         safe_head,
+        agreed_l2_output_root,
         &mut l1_provider,
         &mut l2_provider,
     )

--- a/bin/client/src/single.rs
+++ b/bin/client/src/single.rs
@@ -82,9 +82,26 @@ where
         ));
     }
 
-    // In the case where the agreed upon L2 output root is the same as the claimed L2 output root,
-    // trace extension is detected and we can skip the derivation and execution steps.
-    if boot.agreed_l2_output_root == boot.claimed_l2_output_root {
+    // If the claim targets the safe head block itself, then no derivation is required. This can
+    // happen at trace-extension leaves where the trace is capped at the root-claim block number.
+    //
+    // In this case, the only valid output root is the agreed output root (a zero-step transition).
+    if boot.claimed_l2_block_number == safe_head.number {
+        if boot.claimed_l2_output_root != boot.agreed_l2_output_root {
+            error!(
+                target: "client",
+                claimed = boot.claimed_l2_block_number,
+                safe = safe_head.number,
+                expected_output_root = ?boot.agreed_l2_output_root,
+                claimed_output_root = ?boot.claimed_l2_output_root,
+                "Claimed output root does not match agreed output root at safe head",
+            );
+            return Err(FaultProofProgramError::InvalidClaim(
+                boot.agreed_l2_output_root,
+                boot.claimed_l2_output_root,
+            ));
+        }
+
         info!(
             target: "client",
             "Trace extension detected. State transition is already agreed upon.",
@@ -100,6 +117,7 @@ where
     let cursor = new_oracle_pipeline_cursor(
         rollup_config.as_ref(),
         safe_head,
+        boot.agreed_l2_output_root,
         &mut l1_provider,
         &mut l2_provider,
     )

--- a/bin/client/testdata/trace_extension.rs
+++ b/bin/client/testdata/trace_extension.rs
@@ -1,0 +1,150 @@
+use alloy_consensus::Header;
+use alloy_primitives::B256;
+use async_trait::async_trait;
+use kona_client::single::{FaultProofProgramError, run};
+use kona_preimage::{
+    HintWriterClient, PreimageKey, PreimageOracleClient,
+    errors::{PreimageOracleError, PreimageOracleResult},
+};
+use std::{collections::HashMap, sync::Arc};
+use tokio::sync::Mutex;
+
+#[derive(Clone, Debug, Default)]
+struct MockOracle {
+    preimages: Arc<Mutex<HashMap<PreimageKey, Vec<u8>>>>,
+}
+
+impl MockOracle {
+    fn from_preimages(preimages: HashMap<PreimageKey, Vec<u8>>) -> Self {
+        Self { preimages: Arc::new(Mutex::new(preimages)) }
+    }
+}
+
+#[async_trait]
+impl PreimageOracleClient for MockOracle {
+    async fn get(&self, key: PreimageKey) -> PreimageOracleResult<Vec<u8>> {
+        self.preimages.lock().await.get(&key).cloned().ok_or(PreimageOracleError::KeyNotFound)
+    }
+
+    async fn get_exact(&self, key: PreimageKey, buf: &mut [u8]) -> PreimageOracleResult<()> {
+        let data = self.get(key).await?;
+        if data.len() != buf.len() {
+            return Err(PreimageOracleError::BufferLengthMismatch(buf.len(), data.len()));
+        }
+        buf.copy_from_slice(&data);
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+struct MockHintWriter {
+    _hints: Arc<Mutex<Vec<String>>>,
+}
+
+#[async_trait]
+impl HintWriterClient for MockHintWriter {
+    async fn write(&self, hint: &str) -> PreimageOracleResult<()> {
+        self._hints.lock().await.push(hint.to_string());
+        Ok(())
+    }
+}
+
+fn b256(fill: u8) -> B256 {
+    B256::from([fill; 32])
+}
+
+fn setup_preimages(
+    agreed_root: B256,
+    claimed_root: B256,
+    claimed_block_number: u64,
+    safe_head_hash: B256,
+    safe_head_number: u64,
+) -> HashMap<PreimageKey, Vec<u8>> {
+    let mut preimages = HashMap::new();
+
+    // BootInfo local keys (see `kona_proof::boot`):
+    // 1: L1 head hash, 2: agreed output root, 3: claimed output root, 4: claimed block number,
+    // 5: chain id.
+    preimages.insert(PreimageKey::new_local(1), b256(0x11).as_slice().to_vec());
+    preimages.insert(PreimageKey::new_local(2), agreed_root.as_slice().to_vec());
+    preimages.insert(PreimageKey::new_local(3), claimed_root.as_slice().to_vec());
+    preimages.insert(PreimageKey::new_local(4), claimed_block_number.to_be_bytes().to_vec());
+    preimages.insert(PreimageKey::new_local(5), 10u64.to_be_bytes().to_vec());
+
+    // Output root preimage for `fetch_safe_head_hash(...)`. The safe head hash is read from
+    // bytes [96..128].
+    let mut output_root_preimage = [0u8; 128];
+    output_root_preimage[96..128].copy_from_slice(safe_head_hash.as_slice());
+    preimages.insert(PreimageKey::new_keccak256(*agreed_root), output_root_preimage.to_vec());
+
+    // L2 safe head header.
+    let header = Header { number: safe_head_number, ..Default::default() };
+    let header_rlp = alloy_rlp::encode(&header).to_vec();
+    preimages.insert(PreimageKey::new_keccak256(*safe_head_hash), header_rlp);
+
+    preimages
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn trace_extension_leaf_rejects_zero_claimed_output_root() {
+    let safe_head_number = 3;
+    let safe_head_hash = b256(0x22);
+    let agreed_root = b256(0xAA);
+    let claimed_root = B256::ZERO;
+
+    let oracle = MockOracle::from_preimages(setup_preimages(
+        agreed_root,
+        claimed_root,
+        safe_head_number,
+        safe_head_hash,
+        safe_head_number,
+    ));
+    let hints = MockHintWriter::default();
+
+    let err = run(oracle, hints).await.unwrap_err();
+    match err {
+        FaultProofProgramError::InvalidClaim(expected, actual) => {
+            assert_eq!(expected, agreed_root);
+            assert_eq!(actual, claimed_root);
+        }
+        other => panic!("unexpected error: {other:?}"),
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn trace_extension_leaf_accepts_matching_output_root() {
+    let safe_head_number = 3;
+    let safe_head_hash = b256(0x22);
+    let agreed_root = b256(0xAA);
+
+    let oracle = MockOracle::from_preimages(setup_preimages(
+        agreed_root,
+        agreed_root,
+        safe_head_number,
+        safe_head_hash,
+        safe_head_number,
+    ));
+    let hints = MockHintWriter::default();
+
+    run(oracle, hints).await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn does_not_short_circuit_on_root_match_at_different_block() {
+    let safe_head_number = 3;
+    let safe_head_hash = b256(0x22);
+    let agreed_root = b256(0xAA);
+
+    // With the historical bug (checking only `agreed_root == claimed_root`), this would
+    // incorrectly return `Ok(())` without attempting derivation.
+    let oracle = MockOracle::from_preimages(setup_preimages(
+        agreed_root,
+        agreed_root,
+        safe_head_number + 1,
+        safe_head_hash,
+        safe_head_number,
+    ));
+    let hints = MockHintWriter::default();
+
+    assert!(run(oracle, hints).await.is_err());
+}

--- a/bin/host/src/interop/handler.rs
+++ b/bin/host/src/interop/handler.rs
@@ -525,6 +525,7 @@ impl HintHandler for InteropHintHandler {
                         let cursor = new_oracle_pipeline_cursor(
                             rollup_config.as_ref(),
                             safe_head,
+                            B256::ZERO, 
                             &mut l1_provider,
                             &mut l2_provider,
                         )

--- a/crates/proof/proof/src/sync.rs
+++ b/crates/proof/proof/src/sync.rs
@@ -15,6 +15,7 @@ use spin::RwLock;
 pub async fn new_oracle_pipeline_cursor<L1, L2>(
     rollup_config: &RollupConfig,
     safe_header: Sealed<Header>,
+    agreed_l2_output_root: B256,
     chain_provider: &mut L1,
     l2_chain_provider: &mut L2,
 ) -> Result<Arc<RwLock<PipelineCursor>>, OracleProviderError>
@@ -38,7 +39,7 @@ where
 
     // Construct the cursor.
     let mut cursor = PipelineCursor::new(channel_timeout, origin);
-    let tip = TipCursor::new(safe_head_info, safe_header, B256::ZERO);
+    let tip = TipCursor::new(safe_head_info, safe_header, agreed_l2_output_root);
     cursor.advance(origin, tip);
 
     // Wrap the cursor in a shared read-write lock


### PR DESCRIPTION
…estate (#454)

This fixes an issue where the pipeline cursor was initialized with B256::ZERO as the safe head output root. When the derivation pipeline exhausts L1 data (EndOfSource) before deriving any new blocks, the driver returns this zero value instead of the agreed prestate's actual output root, causing the FPP to reject honest claims and accept zero claims.